### PR TITLE
updated package to have compatibility with zig 0.15.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zig-assimp",
+    .name = .zig_assimp,
     .version = "5.3.1",
+    .fingerprint = 0x3e92a7cfbee36ef8,
     .paths = .{
         "build.zig",
         "build.zig.zon",
@@ -9,6 +10,7 @@
         "include",
         "src",
     },
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .assimp = .{
             .url = "https://github.com/assimp/assimp/archive/v5.3.1.tar.gz",


### PR DESCRIPTION
## Upgrade to Zig 0.15.1

This PR upgrades the assimp build configuration to work with Zig 0.15.1, addressing all the breaking changes introduced in the latest release.

### What changed

There were significant changes to the build system API in 0.15.x, particularly around how modules and libraries are created. This required a pretty extensive refactor of build.zig.

**build.zig.zon fixes:**
- Fixed the package name field... it now needs to be an identifier without quotes (changed to `.zig_assimp`)
- Added the new required `fingerprint` field for package verification
- Added `minimum_zig_version` to make requirements explicit

**build.zig migration:**
- Switched from the deprecated `addStaticLibrary` to the new `addLibrary` API with explicit linkage mode
- Refactored to use the new module system... libraries and executables now need a `root_module` created via `createModule()`
- Moved all the compilation settings (include paths, C source files, macros) to operate on `root_module` instead of the compile step directly
- Updated macro definitions... `addCMacro` no longer accepts null, needs empty strings for valueless macros
- Fixed the tokenizer call (`tokenize` → `tokenizeScalar` with char literal)
- Rewrote the uppercase formatter to use the new `std.fmt.Alt` API since `Formatter` was restructured
- Updated Writer type references to use `std.Io.Writer`

### Testing

Built and tested on Linux and WIndows with Zig 0.15.1:
- Static library builds successfully (~55MB)
- Both example programs (C and C++) compile and run without issues
- No regressions in functionality

### Notes

The linkLibC/linkLibCpp calls stay on the compile step itself, not the module... took me a bit to figure that one out. The Zig docs could be clearer on what goes where in the new module system.